### PR TITLE
NetworkService 싱글톤 객체 단순 class로 변경

### DIFF
--- a/DevEvent/Manager/NetworkService.swift
+++ b/DevEvent/Manager/NetworkService.swift
@@ -25,13 +25,11 @@ enum FetchingEventsError: Error {
 /// 데이터 스크래핑을 위해 네트워크 통신을 담당하는 singleton 클래스
 final class NetworkService {
     
-    static let shared = NetworkService()
-    
     var session: URLSessionProtocol
     
-    let githubURLString = "https://github.com/brave-people/Dev-Event/blob/master/README.md"
+    static let githubURLString = "https://github.com/brave-people/Dev-Event/blob/master/README.md"
     
-    private init(session: URLSessionProtocol = URLSession.shared) {
+    init(session: URLSessionProtocol = URLSession.shared) {
         self.session = session
     }
     
@@ -43,7 +41,7 @@ final class NetworkService {
                 return Disposables.create()
             }
 
-            guard let url = URL(string: self.githubURLString) else {
+            guard let url = URL(string: NetworkService.githubURLString) else {
                 single(.failure(FetchingEventsError.urlError))
                 return Disposables.create()
             }

--- a/DevEvent/Utils/DevEventsFetcher.swift
+++ b/DevEvent/Utils/DevEventsFetcher.swift
@@ -28,7 +28,7 @@ final class DevEventsFetcher {
     private var devEvents = BehaviorRelay<[SectionOfEvents]>(value: [])
     
     private init() {
-        self.networkService = NetworkService.shared
+        self.networkService = NetworkService()
         self.parser = Parser()
         
         fetchDevEvents()

--- a/DevEventSlowTests/DevEventSlowTests.swift
+++ b/DevEventSlowTests/DevEventSlowTests.swift
@@ -14,7 +14,6 @@ final class DevEventSlowTests: XCTestCase {
     var urlSession: URLSession!
     
     let networkConnectionManager = NetworkConnectionManager.shared
-    let networkService = NetworkService.shared
     
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -34,7 +33,7 @@ final class DevEventSlowTests: XCTestCase {
         )
         
         // given
-        let url = URL(string: networkService.githubURLString)!
+        let url = URL(string: NetworkService.githubURLString)!
         let promise = expectation(description: "Completion handler invoked")
         var statusCode: Int?
         var responseError: Error?

--- a/DevEventTests/DevEventFakeTests.swift
+++ b/DevEventTests/DevEventFakeTests.swift
@@ -33,9 +33,8 @@ final class DevEventFakeTests: XCTestCase {
         let data = try Data(contentsOf: fileURL)
         
         // Mock URLSession 만들기
-        let networkService = NetworkService.shared
         let urlSessionStub: URLSessionStub = {
-            let urlString = networkService.githubURLString
+            let urlString = NetworkService.githubURLString
             let url = URL(string: urlString)!
             let response = HTTPURLResponse(url: url,
                                            statusCode: 200,
@@ -46,8 +45,7 @@ final class DevEventFakeTests: XCTestCase {
                                        response: response)
         }()
         
-        networkService.session = urlSessionStub
-        
+        let networkService = NetworkService(session: urlSessionStub)
         let promise = expectation(description: "Value received!")
         
         // ✅ when


### PR DESCRIPTION
[지난번 PR](https://github.com/TheSongOfSongs/DevEvent/pull/9)을 바로 닫아서, 코멘트 주신 부분에 대해 새로 PR 날립니다!

우선, NetworkService 클래스를 싱글톤으로 정의한 이유에 대해 생각해보았습니다.
  1. 네트워킹 세션이 생길 때마다 새로 객체를 만들지 않아도 되므로 메모리 공간 낭비가 줄어듦
  2. 전역적으로 접근이 가능하니 (현재는 구현이 되어있지 않지만) 네트워킹 취소와 같은 관리에 편리함
  3. 구현이 쉬움

사실 위 세 가지 이유는 생각을 해봐서 나온거구요, 항상 작성하던 패턴대로 구현한게 가장 큰 이유입니다.   
그래서 굳이 싱글톤으로 구현할 필요가 있는지 고민했고 '현재 프로젝트에서는 네트워킹이 HTML을 가져올 때 한 번만 필요하고, 전역적 접근이 필요없다'라고 결론 내렸습니다. 

### 변경사항
- NetworkService 클래스를 싱글톤을 일반 class형태로 바꾸고, test 코드에서 이니셜라이저로 mockSession을 주입할 수 있도록 변경했습니다.
- NetworkService의 githubURLString 프로퍼티를 static하게 선언하여 객체 생성없이 바로 접근해 사용할 수 있도록 변경했습니다.