### PR TITLE
버그 픽스

### DIFF
--- a/DevEvent.xcodeproj/project.pbxproj
+++ b/DevEvent.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		765FEB8D28ED7472001DF698 /* URLSessionProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 765FEB8C28ED7472001DF698 /* URLSessionProtocol.swift */; };
 		765FEB8F28ED750F001DF698 /* URLSessionDataTaskProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 765FEB8E28ED750F001DF698 /* URLSessionDataTaskProtocol.swift */; };
 		765FEB9F28EE914D001DF698 /* MockData1.html in Resources */ = {isa = PBXBuildFile; fileRef = 765FEB9628EE87FF001DF698 /* MockData1.html */; };
+		767681912935C0D4007C99BE /* EventDetailValueTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 767681902935C0D4007C99BE /* EventDetailValueTransformer.swift */; };
 		76B5516327E758D700D66BB8 /* ToasterMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76B5516227E758D700D66BB8 /* ToasterMessage.swift */; };
 		76FB9CDD27D30521001EC0F5 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76FB9CDC27D30521001EC0F5 /* AppDelegate.swift */; };
 		76FB9CDF27D30521001EC0F5 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76FB9CDE27D30521001EC0F5 /* SceneDelegate.swift */; };
@@ -112,6 +113,7 @@
 		765FEB8C28ED7472001DF698 /* URLSessionProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionProtocol.swift; sourceTree = "<group>"; };
 		765FEB8E28ED750F001DF698 /* URLSessionDataTaskProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionDataTaskProtocol.swift; sourceTree = "<group>"; };
 		765FEB9628EE87FF001DF698 /* MockData1.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = MockData1.html; sourceTree = "<group>"; };
+		767681902935C0D4007C99BE /* EventDetailValueTransformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventDetailValueTransformer.swift; sourceTree = "<group>"; };
 		76B5516227E758D700D66BB8 /* ToasterMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToasterMessage.swift; sourceTree = "<group>"; };
 		76FB9CD927D30521001EC0F5 /* DevEvent.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DevEvent.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		76FB9CDC27D30521001EC0F5 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -352,6 +354,7 @@
 				761FBA6227E0BC780066F078 /* EventCoreData+CoreDataProperties.swift */,
 				761FBA5927E0A7280066F078 /* EventCoreData+CoreDataClass.swift */,
 				76FB9D3027D43E79001EC0F5 /* Event.swift */,
+				767681902935C0D4007C99BE /* EventDetailValueTransformer.swift */,
 				76FB9D2E27D43E6A001EC0F5 /* SectionOfEvents.swift */,
 			);
 			path = Model;
@@ -702,6 +705,7 @@
 				76FB9D5127D5CEF0001EC0F5 /* WebKitViewController.swift in Sources */,
 				763346B027E2338E00F8BB04 /* FavoriteCoordinator.swift in Sources */,
 				761FBA5B27E0A7280066F078 /* EventCoreData+CoreDataClass.swift in Sources */,
+				767681912935C0D4007C99BE /* EventDetailValueTransformer.swift in Sources */,
 				76B5516327E758D700D66BB8 /* ToasterMessage.swift in Sources */,
 				76FB9D2527D38AC6001EC0F5 /* UIViewController+Extension.swift in Sources */,
 				763346B627E23ECA00F8BB04 /* InfoCoordinator.swift in Sources */,

--- a/DevEvent.xcodeproj/xcshareddata/xcschemes/DevEvent.xcscheme
+++ b/DevEvent.xcodeproj/xcshareddata/xcschemes/DevEvent.xcscheme
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1400"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "76FB9CD827D30521001EC0F5"
+               BuildableName = "DevEvent.app"
+               BlueprintName = "DevEvent"
+               ReferencedContainer = "container:DevEvent.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "76FB9CF127D30522001EC0F5"
+               BuildableName = "DevEventTests.xctest"
+               BlueprintName = "DevEventTests"
+               ReferencedContainer = "container:DevEvent.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "76FB9CFB27D30522001EC0F5"
+               BuildableName = "DevEventUITests.xctest"
+               BlueprintName = "DevEventUITests"
+               ReferencedContainer = "container:DevEvent.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "765FEB7A28EC049A001DF698"
+               BuildableName = "DevEventSlowTests.xctest"
+               BlueprintName = "DevEventSlowTests"
+               ReferencedContainer = "container:DevEvent.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "76FB9CD827D30521001EC0F5"
+            BuildableName = "DevEvent.app"
+            BlueprintName = "DevEvent"
+            ReferencedContainer = "container:DevEvent.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "76FB9CD827D30521001EC0F5"
+            BuildableName = "DevEvent.app"
+            BlueprintName = "DevEvent"
+            ReferencedContainer = "container:DevEvent.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/DevEvent/DevEvent.xcdatamodeld/DevEvent.xcdatamodel/contents
+++ b/DevEvent/DevEvent.xcdatamodeld/DevEvent.xcdatamodel/contents
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19574" systemVersion="21D62" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21279" systemVersion="21G115" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="EventCoreData" representedClassName="EventCoreData" syncable="YES">
-        <attribute name="detail" optional="YES" attributeType="Transformable" customClassName="EventDetail"/>
+        <attribute name="detail" optional="YES" attributeType="Transformable" valueTransformerName="EventDetailValueTransformer" customClassName="EventDetail"/>
         <attribute name="name" optional="YES" attributeType="String"/>
         <attribute name="registeredDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="url" optional="YES" attributeType="URI"/>
     </entity>
-    <elements>
-        <element name="EventCoreData" positionX="-63" positionY="-18" width="128" height="89"/>
-    </elements>
 </model>

--- a/DevEvent/Manager/PersistanceManager.swift
+++ b/DevEvent/Manager/PersistanceManager.swift
@@ -29,6 +29,9 @@ final class PersistanceManager {
     
     // MARK: - init
     private init() {
+        // CoreData stack이 초기화되기 전에 value transformer가 등록되어야 함
+        EventDetailValueTransformer.register()
+        
         appDelegate = UIApplication.shared.delegate as! AppDelegate
         context = appDelegate.persistentContainer.viewContext
         fetchEvents()

--- a/DevEvent/Model/Event.swift
+++ b/DevEvent/Model/Event.swift
@@ -32,7 +32,10 @@ extension Event {
     }
 }
 
-public class EventDetail: NSObject, NSCoding {
+public class EventDetail: NSObject, NSSecureCoding {
+    
+    public static var supportsSecureCoding: Bool = true
+    
     var category: String?
     var host: String?
     var eventPeriodName: String?

--- a/DevEvent/Model/EventDetailValueTransformer.swift
+++ b/DevEvent/Model/EventDetailValueTransformer.swift
@@ -1,0 +1,27 @@
+//
+//  EventDetailValueTransformer.swift
+//  DevEvent
+//
+//  Created by Jinhyang Kim on 2022/11/29.
+//
+
+import Foundation
+
+// It has to be a subclass of `NSSecureUnarchiveFromDataTransformer` and we need to expose it to ObjC.
+@objc(EventDetailValueTransformer)
+final class EventDetailValueTransformer: NSSecureUnarchiveFromDataTransformer {
+
+    // The name of the transformer. This is what we will use to register the transformer `ValueTransformer.setValueTrandformer(_"forName:)`.
+    static let name = NSValueTransformerName(rawValue: String(describing: EventDetailValueTransformer.self))
+
+    // Our class `EventDetail` should in the allowed class list. (This is what the unarchiver uses to check for the right class)
+    override static var allowedTopLevelClasses: [AnyClass] {
+        return [EventDetail.self]
+    }
+
+    // Registers the transformer.
+    public static func register() {
+        let transformer = EventDetailValueTransformer()
+        ValueTransformer.setValueTransformer(transformer, forName: name)
+    }
+}

--- a/DevEvent/View/DevEventTableViewCell.xib
+++ b/DevEvent/View/DevEventTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -23,7 +23,7 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                     <imageView hidden="YES" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="star.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="DPg-Vz-pzn">
-                        <rect key="frame" x="229" y="47.5" width="15" height="15"/>
+                        <rect key="frame" x="229" y="45.5" width="15" height="15"/>
                         <color key="tintColor" systemColor="systemYellowColor"/>
                         <constraints>
                             <constraint firstAttribute="width" secondItem="DPg-Vz-pzn" secondAttribute="height" multiplier="1:1" id="8kC-4Y-qMf"/>
@@ -70,8 +70,8 @@
                     <constraint firstItem="wZl-sF-DOQ" firstAttribute="top" secondItem="cdo-Qg-vrD" secondAttribute="bottom" constant="5" id="dVy-vd-4hh"/>
                     <constraint firstItem="wZl-sF-DOQ" firstAttribute="leading" secondItem="cdo-Qg-vrD" secondAttribute="leading" constant="3" id="rNS-aD-jg3"/>
                     <constraint firstAttribute="bottom" secondItem="wZl-sF-DOQ" secondAttribute="bottom" constant="27.5" id="tel-yc-Jc2"/>
-                    <constraint firstItem="DPg-Vz-pzn" firstAttribute="centerY" secondItem="cdo-Qg-vrD" secondAttribute="centerY" id="u5g-cq-aIh"/>
                     <constraint firstAttribute="trailing" secondItem="ZuT-oQ-4pf" secondAttribute="trailing" constant="10" id="uie-tT-AX4"/>
+                    <constraint firstItem="DPg-Vz-pzn" firstAttribute="centerY" secondItem="ZuT-oQ-4pf" secondAttribute="centerY" id="zB9-7X-grd"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>


### PR DESCRIPTION
**1. CoreData 저장소에 데이터를 저장하거나 불러올 때마다 뜨는 경고문 이슈 해결**
> 'NSKeyedUnarchiveFromData' should not be used to for un-archiving and will be removed in a future releases
- iOS13부터 저장하려는 데이터 타입이 CustomType인 경우, NSCoding이 아닌 NSSecureCoding을 채택하도록 애플에서 권장합니다. EventDetail란 구조체가 NSCoding 대신 NSSecureCoding을 하도록 변경하였습니다.
- EventDetailValueTransformer라는 클래스를 생성하여 데이터를 언어카이빙할 수 있도록 하였습니다.   
<br/>  

**2.tableView cell의 즐겨찾기 별이 세로정렬 되어있지 않은 이슈**
<div>
<img width="291" alt="스크린샷 2022-11-29 오후 3 44 21" src="https://user-images.githubusercontent.com/46002818/204458623-881ad73a-ddcd-4f90-ad7e-8a048183e86d.png">
<img width="291" alt="스크린샷 2022-11-29 오후 3 43 27" src="https://user-images.githubusercontent.com/46002818/204458524-619b35ec-f97b-4327-b994-e04827f10b1d.png">
</div>
 
- 즐겨찾기를 표시하는 '별 이미지 뷰'의 vertical center 값이 hostLabel의 중심으로 맞춰져 있어, 제목이 2줄 이상인 경우 hostLabel의 위치와 함께 별 이미지 뷰의 위치도 중심에서 내려와 어긋나보이는 이슈가 있었습니다. 이 부분을 별의 vertical center 값을 cell의 배경에 깔린 RoundedBackgroundView의 center값에 맞추었습니다.

