### PR TITLE
종료된 이벤트 날짜 안보이는 이슈

### DIFF
--- a/DevEvent/Model/Event.swift
+++ b/DevEvent/Model/Event.swift
@@ -44,8 +44,8 @@ public class EventDetail: NSObject, NSSecureCoding {
     public func encode(with coder: NSCoder) {
         coder.encode(category, forKey: "category")
         coder.encode(host, forKey: "host")
-        coder.encode(host, forKey: "eventPeriodName")
-        coder.encode(host, forKey: "duration")
+        coder.encode(eventPeriodName, forKey: "eventPeriodName")
+        coder.encode(duration, forKey: "duration")
     }
     
     public required init?(coder: NSCoder) {
@@ -57,11 +57,14 @@ public class EventDetail: NSObject, NSSecureCoding {
             self.host = host as String
         }
         
-        if let eventPeriodName = eventPeriodName {
+        // TODO: host와 eventPeriodName, duration 다른지 확인하는 legacy 코드 삭제하기
+        if let eventPeriodName = coder.decodeObject(of: NSString.self, forKey: "eventPeriodName"),
+           (self.host ?? "") != eventPeriodName as String {
             self.eventPeriodName = eventPeriodName as String
         }
         
-        if let duration = duration {
+        if let duration = coder.decodeObject(of: NSString.self, forKey: "duration"),
+           (self.host ?? "") != duration as String {
             self.duration = duration as String
         }
     }

--- a/DevEvent/View/DevEventTableViewCell.swift
+++ b/DevEvent/View/DevEventTableViewCell.swift
@@ -57,12 +57,9 @@ class DevEventTableViewCell: UITableViewCell {
     }
     
     func updateWith(event: Event, setFavoriteImageViewHidden: Bool? = nil) {
-        titleLabel.text = event.name
+        updateEventDetail(with: event)
         
-        if let detail = event.detail {
-            hostLabel.text = detail.host
-            dateLabel.text = "\(detail.eventPeriodName ?? ""): \(detail.duration ?? "")"
-        }
+        titleLabel.text = event.name
         
         if let setFavoriteImageViewHidden = setFavoriteImageViewHidden {
             favoriteImageView.isHidden = setFavoriteImageViewHidden
@@ -73,5 +70,20 @@ class DevEventTableViewCell: UITableViewCell {
     
     func updateUIForFavorite() {
         titleTrailingConstraint.constant = 20
+    }
+    
+    func updateEventDetail(with event: Event) {
+        guard let detail = event.detail else {
+            return
+        }
+        
+        hostLabel.text = detail.host
+        
+        guard let eventPeriodName = detail.eventPeriodName,
+              let duration = detail.duration else {
+            return
+        }
+        
+        dateLabel.text = "\(eventPeriodName): \(duration)"
     }
 }


### PR DESCRIPTION
**문제 상황**
이벤트를 즐겨찾기하면 CoreData를 이용하여 이벤트 정보를 저장합니다. 즐겨찾기 목록에서 종료된 이벤트에서 이벤트 날짜정보(eventPeriodName, duration)가 누락되어 해당 데이터를 화면에 표시해줘야 합니다. 다만, 이전 기획에서는 날짜 정보에 대한 값을 저장할 필요가 없어 날짜 정보 대신 이벤트 호스트에 대한 값을 가데이터처럼 저장하고 있습니다. 현재는 즐겨찾기 추가한 목록의 날짜 정보는 표시되고 있지 않습니다.

**개선**
즐겨찾기 추가된 이벤트 객체의 생성자는 날짜 정보가 이벤트 호스트와 값이 같은지 확인을 합니다. 같으면 날짜 정보 라벨의 텍스트를 빈문자열로 대체하고, 같지 않을 경우 이벤트 객체가 갖고 있는 날짜 정보를 표시합니다.