### PR TITLE
ActivityIndicatorView가 보이지 않는 이슈

### DIFF
--- a/DevEvent/Utils/DevEventsFetcher.swift
+++ b/DevEvent/Utils/DevEventsFetcher.swift
@@ -25,7 +25,7 @@ final class DevEventsFetcher {
     let parser: Parser
     let disposeBag = DisposeBag()
     
-    private var devEvents = BehaviorRelay<[SectionOfEvents]>(value: [])
+    private var devEvents = PublishRelay<[SectionOfEvents]>()
     
     private init() {
         self.networkService = NetworkService()

--- a/DevEvent/ViewModel/HomeViewModel.swift
+++ b/DevEvent/ViewModel/HomeViewModel.swift
@@ -24,7 +24,7 @@ final class HomeViewModel: ViewModelType {
     private lazy var devEventsFetcherInput = DevEventsFetcher.Input(requestFetchingEvents: requestFetchingEvents)
     private lazy var devEventsFetcherOutput = DevEventsFetcher.shared.transform(input: devEventsFetcherInput)
     
-    private let eventsFromServer: BehaviorRelay<[SectionOfEvents]> = BehaviorRelay(value: [])
+    private let eventsFromServer = PublishRelay<[SectionOfEvents]>()
     private let favoriteEvents: BehaviorRelay<[EventCoreData]> = BehaviorRelay(value: [])
     
     let disposeBag = DisposeBag()


### PR DESCRIPTION
**문제**
특정 시점부터 앱 실행 시 동작하는 ActivityIndicatorView가 보이지 않는 문제가 발생했습니다.

**개선**
HomeVC 뷰모델의 데이터소스를 구독하고 있고 데이터를 받으면 ActivityIndicatorView는 사라집니다. 데이터는 DevEventsFetcher에서 HomeViewModel을 거쳐 HomeVC로 전달됩니다. 과정에서 BehaviorRelay로 정의된 객체에서 초기값인 빈 데이터를 전달됩니다. 따라서 BehaviorRelay 대신에 PublishRelay를 사용하여 초기값을 주지 않고, 네트워킹이 완료된 후 데이터가 전달되도록 하였습니다.
데이터는 .combineLatest 메서드를 사용하여 서버에서 가져온 데이터와 CoreData에 저장된 데이터를 가져와 가공하여 전달됩니다. 이 때 CoreData에서 가져오는 데이터 역시 BehaviorRelay로 정의되어 있습니다. 만약 PublishRelay로 변경된다면 CoreData에서 데이터를 가져오고 HomeVC에서 뷰모델과 바인딩되어 이미 배출된 데이터를 가져올 수 없습니다. 필수적으로 BehaviorRelay를 사용해야 하므로 변경하지 않았습니다.